### PR TITLE
upgrade dependencies, add source_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In your Fluentd configuration, use @type timber:
 <match your_match>
   @type timber
   api_key xxxxxxxxxxxxxxxxxxxxxxxxxxx        # Your Timber API (required)
+  source_id xxxxxxx                          # Your Timber Source ID (required)
   hostname "#{Socket.gethostname}"           # Your hostname (required)
   # ip 127.0.0.1                             # IP address (optional)
   buffer_chunk_limit 1m                      # Must be < 5m

--- a/fluent-plugin-timber.gemspec
+++ b/fluent-plugin-timber.gemspec
@@ -3,7 +3,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'fluent-plugin-timber'
-  s.version     = '2.0.0'
+  s.version     = '2.0.1'
   s.date        = Date.today.to_s
   s.summary     = 'Timber.io plugin for Fluentd'
   s.description = 'Streams Fluentd logs to the Timber.io logging service.'
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 2.0.0".freeze)
 
   s.add_runtime_dependency('fluentd', '>= 0.12.0', '< 2')
-  s.add_runtime_dependency('http', '~> 2.0', '>= 2.0.3')
+  s.add_runtime_dependency('http', '~> 4.0')
 
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('test-unit', '~> 3.1.0')
-  s.add_development_dependency('webmock', '~> 2.3')
+  s.add_development_dependency('webmock', '~> 3.8')
 end

--- a/lib/fluent/plugin/out_timber.rb
+++ b/lib/fluent/plugin/out_timber.rb
@@ -16,6 +16,7 @@ module Fluent
     USER_AGENT = "Timber Logstash/#{VERSION}".freeze
 
     config_param :api_key, :string, secret: true
+    config_param :source_id, :string, secret: true
     config_param :hostname, :string
     config_param :ip, :string, default: nil
 

--- a/spec/fluent/plugin/out_timber_spec.rb
+++ b/spec/fluent/plugin/out_timber_spec.rb
@@ -5,6 +5,7 @@ describe Fluent::TimberOutput do
   let(:config) do
     %{
       api_key  abcd1234
+      source_id 81293
       hostname my.host.com
     }
   end
@@ -30,10 +31,12 @@ describe Fluent::TimberOutput do
 
   describe "#write" do
     it "should send a chunked request to the Timber API" do
-      stub = stub_request(:post, "https://logs.timber.io/frames").
+      stub = stub_request(:post, "https://logs.timber.io/sources/81293/frames").
         with(
-          :body => start_with("\x85\xA3age\x1A\xAArequest_id\xA242\xA9parent_id\xA6parent\xAArouting_id\xA7routing\xA2dt\xB4".force_encoding("ASCII-8BIT")),
-          :headers => {'Authorization'=>'Basic YWJjZDEyMzQ=', 'Connection'=>'Keep-Alive', 'Content-Type'=>'application/msgpack', 'User-Agent'=>'Timber Logstash/1.0.0'}
+          :body => start_with(
+              "\x85\xA3age\x1A\xAArequest_id\xA242\xA9parent_id\xA6parent\xAArouting_id\xA7routing\xA2dt\xB4".force_encoding("ASCII-8BIT")
+            ),
+          :headers => {'Authorization'=>'Bearer abcd1234', 'Connection'=>'Keep-Alive', 'Content-Type'=>'application/msgpack', 'User-Agent'=>'Timber Logstash/1.0.1'}
         ).
         to_return(:status => 200, :body => "", :headers => {})
 
@@ -44,7 +47,7 @@ describe Fluent::TimberOutput do
     end
 
     it "handles 500s" do
-      stub = stub_request(:post, "https://logs.timber.io/frames").to_return(:status => 500, :body => "", :headers => {})
+      stub = stub_request(:post, "https://logs.timber.io/sources/81293/frames").to_return(:status => 500, :body => "", :headers => {})
 
       driver.emit(record)
       driver.run
@@ -53,7 +56,7 @@ describe Fluent::TimberOutput do
     end
 
     it "handle auth failures" do
-      stub = stub_request(:post, "https://logs.timber.io/frames").to_return(:status => 403, :body => "", :headers => {})
+      stub = stub_request(:post, "https://logs.timber.io/sources/81293/frames").to_return(:status => 403, :body => "", :headers => {})
 
       driver.emit(record)
       driver.run


### PR DESCRIPTION
Fluentd is on Ruby version 2.7+, Timber depends on gem http version 2,
this http gem version was incompatible with Ruby version 2.7+

The error message I was receiving:

> failed to flush the buffer. retry_time=6  chunk="5aed5ba3979ef96048f7e1eee218ab4b" error_class=FrozenError error="can't modify frozen String: \"\""

Tests appear to be passing